### PR TITLE
Module GpU - documentation - correction de la documentation

### DIFF
--- a/doc/gpu.yml
+++ b/doc/gpu.yml
@@ -320,12 +320,6 @@ paths:
         - SUP
       parameters:
         - in: query
-          name: geom
-          type: string
-          required: false
-          description: Géométrie GeoJSON utilisée pour la recherche
-
-        - in: query
           name: partition
           type: string
           required: false


### PR DESCRIPTION
/api/gpu/acte-sup - suppression paramètre geom non supporté (closes #58)
