### PR TITLE
Modification redirection apicarto.ign.fr

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,13 @@ app.get('/api/doc/:moduleName', function(req,res){
     res.render('module',{moduleName: req.params.moduleName});
 });
 
+app.get('/', function (req, res) {
+    res.redirect('/api/doc/');
+});
+
+app.get('/api/', function (req, res) {
+    res.redirect('/api/doc/');
+});
 /* -----------------------------------------------------------------------------
  * Routes
  -----------------------------------------------------------------------------*/


### PR DESCRIPTION
Redirection https://apicarto.ign.fr/ vers https://apicarto.ign.fr/api/doc/
Redirection https://apicarto.ign.fr/api/ vers https://apicarto.ign.fr/api/doc