### PR TITLE
Petites modifications pour rendre les schema compatibles avec ChatGPT

### DIFF
--- a/doc/aoc.yml
+++ b/doc/aoc.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: API Carto Appellations viticoles
@@ -41,6 +41,8 @@ info:
 
         `{"type":"LineString","coordinates":[[4.681549,47.793784],[4.741974,47.788248]]}`
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/aoc/appellation-viticole:
     post:

--- a/doc/apicarto_chatpgt.yml
+++ b/doc/apicarto_chatpgt.yml
@@ -1,0 +1,4504 @@
+openapi: '3.1.0'
+info:
+  version: '2.7.7'
+  title: API Carto multi-modules ChatGPT
+  description: >
+    Schema OpenAPI de l'API Carto général incluant:
+      - aoc: module appellations viticoles
+      - cadastre: service d’interrogation du cadastre
+      - codes-postaux: communes associées à un code postal
+      - corse: informations sur différentes couches fournis par la Dreal Corse
+      - er: informations sur différentes couches de l'espace revendeur
+      - nature: obtenir les informations sur différentes couches réserves naturelles et natura 2000.
+      - rpg:  informations du registre parcellaire graphique
+      - wfs-geoportail: intersecter toute couche WFS du géoportail exprimée dans le référentiel géographique WGS84
+
+      les appels au module gpu ont volontairement été laissées pour limiter le nombre de routes au dessous de 30 et rester compatible avec les critères de ChatGPT
+
+servers:
+  - url: https://apicarto.ign.fr
+paths:
+  /api/aoc/appellation-viticole:
+    post:
+      operationId: postAppellationViticole
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les appellations viticoles intersectantes
+      parameters:
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+      tags:
+        - Appellations viticoles
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/FeatureCollectionAppellationViticole'
+        '400':
+          description: "Paramètres invalide"
+          content:
+            application/json:
+                schema:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/Error'
+        '500':
+          description: "Erreur dans le traitement de la requête"
+          content:
+            application/json:
+                schema:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/Error'
+
+  /api/cadastre/commune:
+    get:
+      operationId: getCommune
+      description: Récupération de la géométrie d'une commune.
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+        
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+            
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 500)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema: 
+            type: integer
+
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+      tags:
+        - Commune
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/FeatureCollectionCommune'
+
+  /api/cadastre/division:
+    get:
+      operationId: getDivision
+      summary: Recherche d'informations sur les divisions parcellaires d'une commune
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec la liste des divisions parcellaires d'une commune
+        * Paramètre insee => Retour des divisions parcellaires d'une commune
+        * Paramètre Insee + section => Retour des divisions parcellaires d'une section dans une commune
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: code_com
+          in: query
+          description: Code de la commune
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères
+          required: false
+          schema:
+            pattern: '\w{2}'
+            type: string
+
+        - name: code_arr
+          in: query
+          description: Code arrondisssement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            pattern: '\d{3}'
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Division BD Parcellaire
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionDivision'
+
+  /api/cadastre/feuille:
+    get:
+      operationId: getFeuille
+      summary: Recherche d'informations sur les feuilles parcellaires d'une commune en utilisant la couche PCI EXPRESS
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec la liste des feuilles d'une commune
+        * Paramètre insee => Retour des feuilles d'une commune
+        * Paramètre Insee + section => Retour des feuilles d'une section dans une commune
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: code_com
+          in: query
+          description: Code de la commune
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères
+          required: false
+          schema:
+            pattern: '\w{2}'
+            type: string
+
+        - name: code_arr
+          in: query
+          description: Code arrondisssement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            pattern: '\d{3}'
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Feuille PCI EXPRESS
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionFeuillePCI'
+
+  /api/cadastre/parcelle:
+    get:
+      operationId: getParcelle
+      summary: Recherche d'informations sur les parcelles cadastrales d'une commune
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec différentes informations sur les parcelles cadastrales.
+      parameters:
+
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères'
+          required: false
+          schema:
+            type: string
+            pattern: '\w{2}'
+
+        - name: numero
+          in: query
+          description: Numero de la parcelle sur 4 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{4}'
+
+        - name: code_arr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+
+        - name: com_abs
+          in: query
+          description: Code commune absorbée
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+          
+      tags:
+        - Parcelle
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionParcelle'
+
+
+  /api/cadastre/localisant:
+    get:
+      operationId: getLocalisant
+      summary: Informations sur les parcelles non vectorisées.
+      description: Renvoie une featureCollection de type Point pour centrer le point sur une carte
+      tags:
+        - Localisant
+      parameters:
+
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle
+          required: false
+          schema:
+            type: string
+            pattern: '\w{2}'
+
+        - name: numero
+          in: query
+          description: Numéro de la parcelle sur 4 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{4}'
+
+        - name: code_arr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionLocalisant'
+  /api/codes-postaux/communes/{codePostal}:
+    get:
+      operationId: getCommunesByCodePostal
+      description: Renvoie les communes correspondant à un code postal
+      parameters:
+        - in: path
+          name: codePostal
+          required: true
+          description: Code postal de la commune.
+          schema:
+            type: string
+      tags:
+        - codes-postaux
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Commune'
+                  
+  /api/corse/foretcorse:
+    get:
+      operationId: getForetCorse
+      summary: Recherche des zones en Corse sur les Forêts bénéficiant du régime forestier
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Foret Corse
+      parameters:
+
+        - name: ccod_frt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: llib_frt
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: propriete
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: s_sig_ha
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: nom_fore
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: dpt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionCorseForet'
+
+  /api/corse/pechecorse:
+    get:
+      operationId: getPecheCorse
+      summary: Recherche des zones de pêche en Corse
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Peche Corse
+      parameters:
+        - name: dpt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionCorsePeche'
+
+  /api/corse/search:
+    get:
+      operationId: getSearch
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend la source de donnée issue de https://georchestra.ac-corse.fr/geoserver/ à interroger en paramètre d'entrée
+      tags:
+        - Touslesflux
+      parameters:
+        - name: source
+          in: query
+          description: Source des données geochestra.ac-corse
+          required: true
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+        
+      responses:
+        '200':
+          description: Success
+
+  /api/er/product:
+      get:
+        operationId: getProduct
+        summary: Recherche des produits de l'espace revendeurs
+        description: |
+          Retourne un résultat de Type "FeatureCollection".
+        tags:
+          - product
+        parameters:
+          - name: code_ean
+            in: query
+            required: false
+            schema:
+              type: string
+
+          - name: code_article
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: name
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: publication_date
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: geom
+            in: query
+            description: Géométrie au format GeoJson
+            schema:
+              $ref: '#/components/schemas/Geometry'
+        
+          - name: date_maj_deb
+            in: query
+            description: Date début de mise à jour sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: date_maj_fin
+            in: query
+            description: Date fin de mise à jour sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: publi_date_deb
+            in: query
+            description: Date de publication début sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: publi_date_fin
+            in: query
+            description: Date de publication fin sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: depubli_date_deb
+            in: query
+            description: Date de dépublication début sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: depubli_date_fin
+            in: query
+            description: Date de dépublication fin sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: _limit
+            in: query
+            description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+            required: false
+            schema:
+              type: integer
+            
+          - name: _start
+            in: query
+            description: Position pour le début de la recherche
+            required: false
+            schema:
+              type: integer
+
+          - name: _propertyNames
+            in: query
+            description: liste des propriétes à afficher séparées par un ;
+            required: false
+            schema:
+              type: string
+            
+
+        
+        responses:
+          '200':
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/FeatureCollectionProduct'
+
+  /api/er/grid:
+    get:
+      operationId: getGrid
+      summary: Recherche des informations sur les produits
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      parameters:
+        - name: name
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            minLength: 5
+            maxLength: 5
+
+        - name: title
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: zip_codes
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+        - name: _propertyNames
+          in: query
+          description: liste des propriétes à afficher séparées par un ;
+          required: false
+          schema:
+            type: string
+          
+      tags:
+        - grid
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json::
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionGrid'
+
+  /api/er/category:
+    get:
+      operationId: getCategory
+      summary: Recherche d'informations en se basant sur les catégories des produits
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      parameters:
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: type
+          in: query
+          description: Les valeurs autorisées sont t ou c ou s
+          required: false
+          schema:
+            type: string
+
+        - name: category_id
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: _propertyNames
+          in: query
+          description: liste des propriétes à afficher séparées par un ;
+          required: false
+          schema:
+            type: string
+           
+      tags:
+        - category
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionCategory'
+
+  /api/nature/natura-habitat:
+    get:
+      operationId: getNaturaHabitat
+      summary: Récupération de la géométrie pour natura 2000 au titre de la directive habitat
+      description: |
+        Retourne un résultat de Type "FeatureCollection".
+      parameters:
+
+        - name: sitecode
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+            
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - Natura 2000 directive habitat
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatura'
+
+  /api/nature/natura-oiseaux:
+    get:
+      operationId: getNaturaOiseaux
+      summary: Récupération de la géométrie pour natura 2000 au titre de la directive oiseaux
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      parameters:
+        - name: sitecode
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Natura 2000 directives oiseaux
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatura'
+
+  /api/nature/rnc:
+    get:
+      operationId: getRnc
+      summary: Recherche d'informations sur les réserves naturelles de Corse
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      tags:
+        - Réserves naturelles de Corse
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+
+  /api/nature/rnn:
+    get:
+      operationId: getRnn
+      summary: Recherche d'informations sur les réserves naturelles hors Corse
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      tags:
+        - Réserves naturelles hors corse
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+  
+
+
+  /api/nature/znieff1:
+    get:
+      operationId: getZnieff1
+      summary: Recherche d'informations sur des Zones écologiques de nature remarquable
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      
+      tags:
+        - znieff1
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+
+  /api/nature/znieff2:
+    get:
+      operationId: getZnieff2
+      summary: Recherche d'informations sur des Zones écologiques de nature remarquable
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - znieff2
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+  /api/nature/pn:
+    get:
+      operationId: getPn
+      summary: Recherche des zones dans les parcs nationaux
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Parcs nationaux
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            pplication/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+  /api/nature/pnr:
+    get:
+      operationId: getPnr
+      summary: Recherche des zones dans les  parcs naturels régionaux
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Parcs naturels régionaux
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+  
+
+  /api/nature/rncf:
+    get:
+      operationId: getRncf
+      summary: Recherche des réserves nationales de chasse et de faune sauvage
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Réserves nationales de chasse et de faune sauvage
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureChassePeche'
+
+  /api/wfs-geoportail/search:
+    get:
+      operationId: getWfsSearch
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend la source de donnée WFS Géoportail à interroger en paramètre d'entrée
+
+      parameters:  
+        - name: source
+          in: query
+          description: Source des données WFS Géoportail
+          required: true
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+      tags:
+        - Geoportail
+      responses:
+        '200':
+          description: "Succès"
+
+  /api/rpg/v1:
+    get:
+      operationId: getV1
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend une date qui sera une valeur comprise entre 2010 et 2014 inclus.
+        Les champs année et geom sont obligatoires.
+      parameters:
+
+        - name: annee
+          in: query
+          required: true
+          schema:
+            type: integer
+            pattern: '\d{4}'
+
+        - name: code_cultu
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Le champ geom est obligatoire pour la recherche
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - RPG avant 2015
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureCollectionRPGAvant2015"
+
+  /api/rpg/v2:
+    get:
+      operationId: getV2
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend une date qui sera une valeur comprise entre 2015 et 2022 inclus.
+        Les champs année et geom sont obligatoires.
+        
+      parameters:
+        - name: annee
+          in: query
+          required: true
+          schema:
+            type: integer
+            pattern: '\d{4}'
+
+        - name: code_cultu
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Le champ geom est obligatoire pour la recherche
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - RPG à partir de 2015
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureCollectionRPGApartirde2015"
+
+
+components:
+  schemas:
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+    
+    FeatureAppellationViticole:
+      description: Objet géographique appellation viticole
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Feature"
+      properties:
+        properties:
+          type: object
+          properties:
+            appelation:
+              type: string        
+            idapp:
+              type: string
+            id_uni:
+              type: string
+              description: corresponds à "segment-idapp-insee"
+            insee:
+              type: string
+            segment:
+              type: string
+            instruction_obligatoire:
+              type: boolean
+            granularite:
+              type: string
+              enum:
+                - commune
+                - exacte
+            appellation:
+              type: string
+            contains:
+              type: boolean
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+    
+    FeatureCollectionAppellationViticole:
+      description: "Liste d'objet géographique appellation viticole"
+      type: object
+      properties:
+        type: 
+          type: string
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureAppellationViticole'
+        
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+    Coordinate:
+      type: array
+      items:
+        type: number
+      minItems: 2
+      maxItems: 4
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    FeatureCollection:
+      type: object
+      description: Une `FeatureCollection` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`FeatureCollection`)
+        features:
+          type: array
+          items: {}
+    Point:
+      type: object
+      description: Un `Point` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`Point`)
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/Coordinate'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+          
+    #---------------------------------------------------
+    # /cadastre/commune
+    #---------------------------------------------------
+  
+    FeatureCommune:
+      description: Une commune
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            nom_commune:
+              type: string
+            code_dep:
+              type: string
+            code_insee:
+              type: string
+        geometry:
+         $ref: '#/components/schemas/MultiPolygon'
+    FeatureCollectionCommune:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCommune`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCommune'
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+    
+    #---------------------------------------------------
+    # /cadastre/division
+    #---------------------------------------------------  
+    
+    FeatureDivision:
+      description: Une division
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon' 
+    FeatureCollectionDivision:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureDivision'
+  
+    #---------------------------------------------------
+    # /cadastre/parcelle
+    #---------------------------------------------------  
+    
+    FeatureParcelle:
+      description: 'Une parcelle'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            numero:
+              type: string
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+
+    FeatureCollectionParcelle:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureParcelle`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureParcelle'
+            
+    #---------------------------------------------------
+    # /cadastre/localisant
+    #---------------------------------------------------
+  
+    FeatureLocalisant:
+      description: 'Un ponctuel localisant une parcelle cadastrale'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            numero:
+              type: string
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/Point'
+  
+    FeatureCollectionLocalisant:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureLocalisant`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureLocalisant'
+
+    #---------------------------------------------------
+    # /cadastre/feuille
+    #---------------------------------------------------
+              
+    FeatureFeuillePCI:
+      description: 'Une feuille'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            nom_comm:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+            code_insee:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionFeuillePCI:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureFeuillePCI`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureFeuillePCI'
+
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    FeatureCollection:
+      type: object
+      description: Une `FeatureCollection` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`FeatureCollection`)
+        features:
+          type: array
+          items: {}
+    Point:
+      type: object
+      description: Un `Point` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`Point`)
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/Coordinate'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+          
+    #---------------------------------------------------
+    # /Corse Forêt/
+    #---------------------------------------------------
+              
+    FeatureCorseForet:
+      description: 'Corse Forêt'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            ccod_frt:
+              type: string
+            llib_frt:
+              type: string
+            propriete:
+              type: string
+            s_sig_ha:
+              type: number
+            nom_fore:
+              type: string
+            dept: 
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'  
+  
+  
+    #---------------------------------------------------
+    # /corse Pêche
+    #---------------------------------------------------
+              
+    FeatureCorsePeche:
+      description: 'Dreal Corse Pêche'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            designatio:
+              type: string
+            dpt:
+              type: string
+            date_arr:
+              type: string
+            date_fin:
+              type: string
+            id_repe:
+              type: integer
+            st_length:
+              type: number
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionCorsePeche:
+      description: Une `FeatureCollection`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCorsePeche'
+  
+    FeatureCollectionCorseForet:
+      description: Une `FeatureCollection`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCorseForet'      
+
+    Coordinate:
+      type: array
+      items:
+        type: number
+      minItems: 2
+      maxItems: 4
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    FeatureCollection:
+      type: object
+      description: Une `FeatureCollection` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`FeatureCollection`)
+        features:
+          type: array
+          items: {}
+    Point:
+      type: object
+      description: Un `Point` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`Point`)
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/Coordinate'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+          
+    #---------------------------------------------------
+    # /er/product/
+    #---------------------------------------------------
+    
+    FeatureProduct:
+      description: 'Products'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            code_ean:
+              type: string
+            code_article:
+              type: string
+            name:
+              type: string
+            name_complement:
+              type: string
+            front_image:
+              type: string
+            back_image:
+              type: string
+            edition_number:
+              type: string
+            publication_date:
+              type: string
+            replacement:
+              type: string
+            dimension:
+              type: string
+            scale:
+              type: string
+            editorial:
+              type: string
+            sale:
+              type: string
+            complement:
+              type: string
+            category_id:
+              type: string
+            segment_title:
+              type: string
+            segment_slug:
+              type: string
+            theme_title:
+              type: string
+            theme_slug:
+              type: string
+            collection_title:
+              type: string
+            collection_slug:
+              type: string
+            background_color:
+              type: string
+            border_color:
+              type: string
+            pricecode:
+              type: string
+            price:
+              type: string
+            price_exlcuding_vat:
+              type: string
+            vat:
+              type: string
+            keywords:
+              type: string
+            ean_symb:
+              type: string
+            producer:
+              type: string
+            previous_publication_date:
+              type: string
+            er_visible_from:
+              type: string
+            er_visible_to:
+              type: string
+            updated_at:
+              type: string
+            deleted_at:
+              type: string
+            continent:
+              type: string
+            pays:
+              type: string
+            has_geometry:
+              type: boolean
+            departement:
+              type: string
+            region:
+              type: string
+            tva_type:
+              type: string
+            print_medium:
+              type: string
+            full_description:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+   
+    #---------------------------------------------------
+    # /er/grid
+    #---------------------------------------------------
+              
+    FeatureGrid:
+      description: 'Grid'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+            zip_codes:
+              type: string
+            title:
+              type: string
+            deleted:
+              type: string
+            children: 
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    #---------------------------------------------------
+    # /er/category
+    #---------------------------------------------------
+    
+    FeatureCategory:
+      description: 'Category'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            code_ean:
+              type: string
+            code_article:
+              type: string
+            name:
+              type: string
+            name_complement:
+              type: string
+            front_image:
+              type: string
+            back_image:
+              type: string
+            edition_number:
+              type: string
+            publication_date:
+              type: string
+            status:
+              type: string
+            replacement:
+              type: string
+            dimension:
+              type: string
+            scale:
+              type: string
+            complement:
+              type: string
+            category_id:
+              type: string
+            segment_title:
+              type: string
+            segment_slug:
+              type: string
+            theme_title:
+              type: string
+            theme_slug:
+              type: string
+            collection_title:
+              type: string
+            collection_slug:
+              type: string
+            background_color:
+              type: string
+            border_color:
+              type: string
+            pricecode:
+              type: string
+            price:
+              type: string
+            price_exlcuding_vat:
+              type: string
+            vat:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionCategory:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionCategory'` 
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCategory'
+  
+    FeatureCollectionGrid:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionGrid`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureGrid'
+  
+    FeatureCollectionProduct:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionProduit` 
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureProduct'
+
+    Coordinate:
+      type: array
+      items:
+        type: number
+      minItems: 2
+      maxItems: 4
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    FeatureCollection:
+      type: object
+      description: Une `FeatureCollection` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`FeatureCollection`)
+        features:
+          type: array
+          items: {}
+    Point:
+      type: object
+      description: Un `Point` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`Point`)
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/Coordinate'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+
+    #---------------------------------------------------
+    # /nature/natura-habitat et natura-oiseaux
+    #---------------------------------------------------
+    
+    FeatureNatura:
+      description: 'Pour les couches natura'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            sitecode:
+              type: string
+            sitename:
+              type: string
+            url:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionNatura:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCommune`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatura'
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    #---------------------------------------------------
+    # /nature/
+    #---------------------------------------------------
+              
+    FeatureNatureAutre:
+      description: 'Nature autres'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            id_mnhn:
+              type: string
+            nom:
+              type: string
+            url:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionNatureAutre:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatureAutre'
+  
+  
+     #---------------------------------------------------
+     # /Chasse et peche
+     #---------------------------------------------------
+              
+    FeatureNatureChassePeche:
+      description: 'Nature autres'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            id_local:
+              type: string
+            id_mnhn:
+              type: string
+            nom_site:
+              type: string
+            date_crea:
+              type: string
+            modif_adm:
+              type: string
+            modif_geo:
+              type: string
+            url_fiche:
+              type: string
+            surf_off:
+              type: string
+            acte_deb:
+              type: string
+            gest_site:
+              type: string
+            operateur:
+              type: string
+            precision:
+              type: string
+            src_geom:
+              type: string
+            src_annee:
+              type: string
+            marin:
+              type: string
+            p1_nature:
+              type: string
+            p2_culture:
+              type: string
+            p3_paysage:
+              type: string
+            p4_geologi:
+              type: string
+            p5_speleo:
+              type: string
+            p6_archeo:
+              type: string
+            p7_paleob:
+              type: string
+            p8_anthrop:
+              type: string
+            p9_science:
+              type: string
+            p10_public:
+              type: string
+            p11_dd:
+              type: string
+            p12_autre:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionNatureChassePeche:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatureChassePeche'
+
+openapi: '3.1.0'
+info:
+  version: '2.7.7'
+  title: API Carto
+
+servers:
+  - url: https://apicarto.ign.fr
+paths:
+  /api/aoc/appellation-viticole:
+    post:
+      operationId: postAppellationViticole
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les appellations viticoles intersectantes
+      parameters:
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+      tags:
+        - Appellations viticoles
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/FeatureCollectionAppellationViticole'
+        '400':
+          description: "Paramètres invalide"
+          content:
+            application/json:
+                schema:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/Error'
+        '500':
+          description: "Erreur dans le traitement de la requête"
+          content:
+            application/json:
+                schema:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/Error'
+
+  /api/cadastre/commune:
+    get:
+      operationId: getCommune
+      description: Récupération de la géométrie d'une commune.
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+        
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+            
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 500)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema: 
+            type: integer
+
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+      tags:
+        - Commune
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/FeatureCollectionCommune'
+
+  /api/cadastre/division:
+    get:
+      operationId: getDivision
+      summary: Recherche d'informations sur les divisions parcellaires d'une commune
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec la liste des divisions parcellaires d'une commune
+        * Paramètre insee => Retour des divisions parcellaires d'une commune
+        * Paramètre Insee + section => Retour des divisions parcellaires d'une section dans une commune
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: code_com
+          in: query
+          description: Code de la commune
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères
+          required: false
+          schema:
+            pattern: '\w{2}'
+            type: string
+
+        - name: code_arr
+          in: query
+          description: Code arrondisssement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            pattern: '\d{3}'
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Division BD Parcellaire
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionDivision'
+
+  /api/cadastre/feuille:
+    get:
+      operationId: getFeuille
+      summary: Recherche d'informations sur les feuilles parcellaires d'une commune en utilisant la couche PCI EXPRESS
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec la liste des feuilles d'une commune
+        * Paramètre insee => Retour des feuilles d'une commune
+        * Paramètre Insee + section => Retour des feuilles d'une section dans une commune
+      parameters:
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: code_dep
+          in: query
+          description: Code du département
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: code_com
+          in: query
+          description: Code de la commune
+          required: false
+          schema:
+            type: string
+            pattern: '\d{2,3}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères
+          required: false
+          schema:
+            pattern: '\w{2}'
+            type: string
+
+        - name: code_arr
+          in: query
+          description: Code arrondisssement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            pattern: '\d{3}'
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Feuille PCI EXPRESS
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionFeuillePCI'
+
+  /api/cadastre/parcelle:
+    get:
+      operationId: getParcelle
+      summary: Recherche d'informations sur les parcelles cadastrales d'une commune
+      description: |
+        Retourne un résultat de Type "FeatureCollection" avec différentes informations sur les parcelles cadastrales.
+      parameters:
+
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle sur 2 caractères'
+          required: false
+          schema:
+            type: string
+            pattern: '\w{2}'
+
+        - name: numero
+          in: query
+          description: Numero de la parcelle sur 4 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{4}'
+
+        - name: code_arr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+
+        - name: com_abs
+          in: query
+          description: Code commune absorbée
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+          
+      tags:
+        - Parcelle
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionParcelle'
+
+
+  /api/cadastre/localisant:
+    get:
+      operationId: getLocalisant
+      summary: Informations sur les parcelles non vectorisées.
+      description: Renvoie une featureCollection de type Point pour centrer le point sur une carte
+      tags:
+        - Localisant
+      parameters:
+
+        - name: code_insee
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{5}'
+
+        - name: section
+          in: query
+          description: Section de la parcelle
+          required: false
+          schema:
+            type: string
+            pattern: '\w{2}'
+
+        - name: numero
+          in: query
+          description: Numéro de la parcelle sur 4 caractères
+          required: false
+          schema:
+            type: string
+            pattern: '\d{4}'
+
+        - name: code_arr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          required: false
+          schema:
+            type: string
+            pattern: '\d{3}'
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: source_ign
+          in: query
+          description: « PCI » pour la ressource Parcellaire Express ou « BDP » pour la ressource BD Parcellaire
+          required: false
+          schema:
+            type: string
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionLocalisant'
+  /api/codes-postaux/communes/{codePostal}:
+    get:
+      operationId: getCommunesByCodePostal
+      description: Renvoie les communes correspondant à un code postal
+      parameters:
+        - in: path
+          name: codePostal
+          required: true
+          description: Code postal de la commune.
+          schema:
+            type: string
+      tags:
+        - codes-postaux
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Commune'
+                  
+  /api/corse/foretcorse:
+    get:
+      operationId: getForetCorse
+      summary: Recherche des zones en Corse sur les Forêts bénéficiant du régime forestier
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Foret Corse
+      parameters:
+
+        - name: ccod_frt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: llib_frt
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: propriete
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: s_sig_ha
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: nom_fore
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: dpt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/FeatureCollectionCorseForet'
+
+  /api/corse/pechecorse:
+    get:
+      operationId: getPecheCorse
+      summary: Recherche des zones de pêche en Corse
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Peche Corse
+      parameters:
+        - name: dpt
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionCorsePeche'
+
+  /api/corse/search:
+    get:
+      operationId: getSearch
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend la source de donnée issue de https://georchestra.ac-corse.fr/geoserver/ à interroger en paramètre d'entrée
+      tags:
+        - Touslesflux
+      parameters:
+        - name: source
+          in: query
+          description: Source des données geochestra.ac-corse
+          required: true
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+        
+      responses:
+        '200':
+          description: Success
+
+  /api/er/product:
+      get:
+        operationId: getProduct
+        summary: Recherche des produits de l'espace revendeurs
+        description: |
+          Retourne un résultat de Type "FeatureCollection".
+        tags:
+          - product
+        parameters:
+          - name: code_ean
+            in: query
+            required: false
+            schema:
+              type: string
+
+          - name: code_article
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: name
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: publication_date
+            in: query
+            required: false
+            schema:
+              type: string
+          
+          - name: geom
+            in: query
+            description: Géométrie au format GeoJson
+            schema:
+              $ref: '#/components/schemas/Geometry'
+        
+          - name: date_maj_deb
+            in: query
+            description: Date début de mise à jour sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: date_maj_fin
+            in: query
+            description: Date fin de mise à jour sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: publi_date_deb
+            in: query
+            description: Date de publication début sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: publi_date_fin
+            in: query
+            description: Date de publication fin sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: depubli_date_deb
+            in: query
+            description: Date de dépublication début sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: depubli_date_fin
+            in: query
+            description: Date de dépublication fin sous la forme AAAA-MM-JJ
+            required: false
+            schema:
+              type: string
+
+          - name: _limit
+            in: query
+            description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+            required: false
+            schema:
+              type: integer
+            
+          - name: _start
+            in: query
+            description: Position pour le début de la recherche
+            required: false
+            schema:
+              type: integer
+
+          - name: _propertyNames
+            in: query
+            description: liste des propriétes à afficher séparées par un ;
+            required: false
+            schema:
+              type: string
+            
+
+        
+        responses:
+          '200':
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/FeatureCollectionProduct'
+
+  /api/er/grid:
+    get:
+      operationId: getGrid
+      summary: Recherche des informations sur les produits
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      parameters:
+        - name: name
+          in: query
+          description: Code insee de la commune sur 5 caractères
+          required: false
+          schema:
+            type: string
+            minLength: 5
+            maxLength: 5
+
+        - name: title
+          in: query
+          required: false
+          schema:
+            type: string
+        
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: zip_codes
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+        - name: _propertyNames
+          in: query
+          description: liste des propriétes à afficher séparées par un ;
+          required: false
+          schema:
+            type: string
+          
+      tags:
+        - grid
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json::
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionGrid'
+
+  /api/er/category:
+    get:
+      operationId: getCategory
+      summary: Recherche d'informations en se basant sur les catégories des produits
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      parameters:
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: type
+          in: query
+          description: Les valeurs autorisées sont t ou c ou s
+          required: false
+          schema:
+            type: string
+
+        - name: category_id
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+        - name: _propertyNames
+          in: query
+          description: liste des propriétes à afficher séparées par un ;
+          required: false
+          schema:
+            type: string
+           
+      tags:
+        - category
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionCategory'
+
+  /api/nature/natura-habitat:
+    get:
+      operationId: getNaturaHabitat
+      summary: Récupération de la géométrie pour natura 2000 au titre de la directive habitat
+      description: |
+        Retourne un résultat de Type "FeatureCollection".
+      parameters:
+
+        - name: sitecode
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+            
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - Natura 2000 directive habitat
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatura'
+
+  /api/nature/natura-oiseaux:
+    get:
+      operationId: getNaturaOiseaux
+      summary: Récupération de la géométrie pour natura 2000 au titre de la directive oiseaux
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      parameters:
+        - name: sitecode
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher(chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      tags:
+        - Natura 2000 directives oiseaux
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatura'
+
+  /api/nature/rnc:
+    get:
+      operationId: getRnc
+      summary: Recherche d'informations sur les réserves naturelles de Corse
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      tags:
+        - Réserves naturelles de Corse
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+
+  /api/nature/rnn:
+    get:
+      operationId: getRnn
+      summary: Recherche d'informations sur les réserves naturelles hors Corse
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+
+      tags:
+        - Réserves naturelles hors corse
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+    
+      
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+  
+
+
+  /api/nature/znieff1:
+    get:
+      operationId: getZnieff1
+      summary: Recherche d'informations sur des Zones écologiques de nature remarquable
+      description: |
+        Retourne un résultat de Type "FeatureCollection"
+      
+      tags:
+        - znieff1
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+          
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+
+  /api/nature/znieff2:
+    get:
+      operationId: getZnieff2
+      summary: Recherche d'informations sur des Zones écologiques de nature remarquable
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - znieff2
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+  /api/nature/pn:
+    get:
+      operationId: getPn
+      summary: Recherche des zones dans les parcs nationaux
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Parcs nationaux
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            pplication/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+
+  /api/nature/pnr:
+    get:
+      operationId: getPnr
+      summary: Recherche des zones dans les  parcs naturels régionaux
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Parcs naturels régionaux
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureAutre'
+  
+
+  /api/nature/rncf:
+    get:
+      operationId: getRncf
+      summary: Recherche des réserves nationales de chasse et de faune sauvage
+      description: Retourne un résultat de Type "FeatureCollection"
+      tags:
+        - Réserves nationales de chasse et de faune sauvage
+      parameters:
+        - name: id_mnhn
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Géométrie au format GeoJson
+          schema:
+            $ref: '#/components/schemas/Geometry'
+          
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+        
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollectionNatureChassePeche'
+
+  /api/wfs-geoportail/search:
+    get:
+      operationId: getWfsSearch
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend la source de donnée WFS Géoportail à interroger en paramètre d'entrée
+
+      parameters:  
+        - name: source
+          in: query
+          description: Source des données WFS Géoportail
+          required: true
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+      tags:
+        - Geoportail
+      responses:
+        '200':
+          description: "Succès"
+
+  /api/rpg/v1:
+    get:
+      operationId: getV1
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend une date qui sera une valeur comprise entre 2010 et 2014 inclus.
+        Les champs année et geom sont obligatoires.
+      parameters:
+
+        - name: annee
+          in: query
+          required: true
+          schema:
+            type: integer
+            pattern: '\d{4}'
+
+        - name: code_cultu
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Le champ geom est obligatoire pour la recherche
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - RPG avant 2015
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureCollectionRPGAvant2015"
+
+  /api/rpg/v2:
+    get:
+      operationId: getV2
+      description: |
+        Prend une geometrie de type GeoJSON en paramètre d'entrée et renvoie les informations intersectant cette géométrie
+        Prend une date qui sera une valeur comprise entre 2015 et 2022 inclus.
+        Les champs année et geom sont obligatoires.
+        
+      parameters:
+        - name: annee
+          in: query
+          required: true
+          schema:
+            type: integer
+            pattern: '\d{4}'
+
+        - name: code_cultu
+          in: query
+          required: false
+          schema:
+            type: string
+
+        - name: geom
+          in: query
+          description: Le champ geom est obligatoire pour la recherche
+          required: true
+          schema:
+            $ref: "#/components/schemas/Geometry"
+
+        - name: _limit
+          in: query
+          description: Limite de résultats à afficher (chiffre entre 1 et 1000)
+          required: false
+          schema:
+            type: integer
+          
+        - name: _start
+          in: query
+          description: Position pour le début de la recherche
+          required: false
+          schema:
+            type: integer
+
+      tags:
+        - RPG à partir de 2015
+      responses:
+        '200':
+          description: "Succès"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureCollectionRPGApartirde2015"
+
+
+components:
+  schemas:
+    Geometry:
+      type: object
+      description: Une `Geometry` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique
+          enum:
+            - Point
+            - LineString
+            - Polygon
+            - MultiPoint
+            - MultiLineString
+            - MultiPolygon
+        coordinates:
+          type: array
+          items: {}
+    Feature:
+      type: object
+      description: Une `Feature` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`Feature`)
+        id:
+          type: string
+        geometry:
+          $ref: '#/components/schemas/Geometry'
+    FeatureCollection:
+      type: object
+      description: Une `FeatureCollection` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type d'objet GeoJSON (`FeatureCollection`)
+        features:
+          type: array
+          items: {}
+    Point:
+      type: object
+      description: Un `Point` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`Point`)
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/Coordinate'
+    MultiPolygon:
+      type: object
+      description: Un `MultiPolygon` au sens GeoJSON
+      properties:
+        type:
+          type: string
+          description: Le type géométrique (`MultiPolygon`)
+        coordinates:
+          type: array
+          items: {}
+    Coordinate:
+      type: array
+      items:
+        type: number
+      minItems: 2
+      maxItems: 4
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+    FeatureAppellationViticole:
+      description: Objet géographique appellation viticole
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Feature"
+      properties:
+        properties:
+          type: object
+          properties:
+            appelation:
+              type: string        
+            idapp:
+              type: string
+            id_uni:
+              type: string
+              description: corresponds à "segment-idapp-insee"
+            insee:
+              type: string
+            segment:
+              type: string
+            instruction_obligatoire:
+              type: boolean
+            granularite:
+              type: string
+              enum:
+                - commune
+                - exacte
+            appellation:
+              type: string
+            contains:
+              type: boolean
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+    
+    FeatureCollectionAppellationViticole:
+      description: "Liste d'objet géographique appellation viticole"
+      type: object
+      properties:
+        type: 
+          type: string
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureAppellationViticole'
+        
+
+    FeatureCommune:
+      description: Une commune
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            nom_commune:
+              type: string
+            code_dep:
+              type: string
+            code_insee:
+              type: string
+        geometry:
+         $ref: '#/components/schemas/MultiPolygon'
+    FeatureCollectionCommune:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCommune`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCommune'
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+    
+    FeatureDivision:
+      description: Une division
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon' 
+    FeatureCollectionDivision:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureDivision'
+  
+    FeatureParcelle:
+      description: 'Une parcelle'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            numero:
+              type: string
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+
+    FeatureCollectionParcelle:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureParcelle`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureParcelle'
+
+    FeatureLocalisant:
+      description: 'Un ponctuel localisant une parcelle cadastrale'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            numero:
+              type: string
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/Point'
+  
+    FeatureCollectionLocalisant:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureLocalisant`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureLocalisant'
+     
+    FeatureFeuillePCI:
+      description: 'Une feuille'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            feuille:
+              type: number
+            section:
+              type: string
+            code_dep:
+              type: string
+            nom_comm:
+              type: string
+            code_com:
+              type: string
+            com_abs:
+              type: string
+            echelle:
+              type: string
+            code_arr:
+              type: string
+            code_insee:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionFeuillePCI:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureFeuillePCI`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureFeuillePCI'
+
+    FeatureCorseForet:
+      description: 'Corse Forêt'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            ccod_frt:
+              type: string
+            llib_frt:
+              type: string
+            propriete:
+              type: string
+            s_sig_ha:
+              type: number
+            nom_fore:
+              type: string
+            dept: 
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'  
+   
+    FeatureCorsePeche:
+      description: 'Dreal Corse Pêche'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            designatio:
+              type: string
+            dpt:
+              type: string
+            date_arr:
+              type: string
+            date_fin:
+              type: string
+            id_repe:
+              type: integer
+            st_length:
+              type: number
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionCorsePeche:
+      description: Une `FeatureCollection`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCorsePeche'
+  
+    FeatureCollectionCorseForet:
+      description: Une `FeatureCollection`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCorseForet'      
+
+    FeatureProduct:
+      description: 'Products'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            code_ean:
+              type: string
+            code_article:
+              type: string
+            name:
+              type: string
+            name_complement:
+              type: string
+            front_image:
+              type: string
+            back_image:
+              type: string
+            edition_number:
+              type: string
+            publication_date:
+              type: string
+            replacement:
+              type: string
+            dimension:
+              type: string
+            scale:
+              type: string
+            editorial:
+              type: string
+            sale:
+              type: string
+            complement:
+              type: string
+            category_id:
+              type: string
+            segment_title:
+              type: string
+            segment_slug:
+              type: string
+            theme_title:
+              type: string
+            theme_slug:
+              type: string
+            collection_title:
+              type: string
+            collection_slug:
+              type: string
+            background_color:
+              type: string
+            border_color:
+              type: string
+            pricecode:
+              type: string
+            price:
+              type: string
+            price_exlcuding_vat:
+              type: string
+            vat:
+              type: string
+            keywords:
+              type: string
+            ean_symb:
+              type: string
+            producer:
+              type: string
+            previous_publication_date:
+              type: string
+            er_visible_from:
+              type: string
+            er_visible_to:
+              type: string
+            updated_at:
+              type: string
+            deleted_at:
+              type: string
+            continent:
+              type: string
+            pays:
+              type: string
+            has_geometry:
+              type: boolean
+            departement:
+              type: string
+            region:
+              type: string
+            tva_type:
+              type: string
+            print_medium:
+              type: string
+            full_description:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+       
+    FeatureGrid:
+      description: 'Grid'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+            zip_codes:
+              type: string
+            title:
+              type: string
+            deleted:
+              type: string
+            children: 
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCategory:
+      description: 'Category'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            code_ean:
+              type: string
+            code_article:
+              type: string
+            name:
+              type: string
+            name_complement:
+              type: string
+            front_image:
+              type: string
+            back_image:
+              type: string
+            edition_number:
+              type: string
+            publication_date:
+              type: string
+            status:
+              type: string
+            replacement:
+              type: string
+            dimension:
+              type: string
+            scale:
+              type: string
+            complement:
+              type: string
+            category_id:
+              type: string
+            segment_title:
+              type: string
+            segment_slug:
+              type: string
+            theme_title:
+              type: string
+            theme_slug:
+              type: string
+            collection_title:
+              type: string
+            collection_slug:
+              type: string
+            background_color:
+              type: string
+            border_color:
+              type: string
+            pricecode:
+              type: string
+            price:
+              type: string
+            price_exlcuding_vat:
+              type: string
+            vat:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionCategory:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionCategory'` 
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureCategory'
+  
+    FeatureCollectionGrid:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionGrid`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureGrid'
+  
+    FeatureCollectionProduct:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCollectionProduit` 
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureProduct'
+    
+    FeatureNatura:
+      description: 'Pour les couches natura'
+      allOf:
+      - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            sitecode:
+              type: string
+            sitename:
+              type: string
+            url:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionNatura:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureCommune`
+      allOf:
+      - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatura'
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+          
+    FeatureNatureAutre:
+      description: 'Nature autres'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            id_mnhn:
+              type: string
+            nom:
+              type: string
+            url:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionNatureAutre:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatureAutre'
+  
+  
+     #---------------------------------------------------
+     # /Chasse et peche
+     #---------------------------------------------------
+              
+    FeatureNatureChassePeche:
+      description: 'Nature autres'
+      allOf:
+        - $ref: '#/components/schemas/Feature'
+      properties:
+        properties:
+          type: object
+          properties:
+            id_local:
+              type: string
+            id_mnhn:
+              type: string
+            nom_site:
+              type: string
+            date_crea:
+              type: string
+            modif_adm:
+              type: string
+            modif_geo:
+              type: string
+            url_fiche:
+              type: string
+            surf_off:
+              type: string
+            acte_deb:
+              type: string
+            gest_site:
+              type: string
+            operateur:
+              type: string
+            precision:
+              type: string
+            src_geom:
+              type: string
+            src_annee:
+              type: string
+            marin:
+              type: string
+            p1_nature:
+              type: string
+            p2_culture:
+              type: string
+            p3_paysage:
+              type: string
+            p4_geologi:
+              type: string
+            p5_speleo:
+              type: string
+            p6_archeo:
+              type: string
+            p7_paleob:
+              type: string
+            p8_anthrop:
+              type: string
+            p9_science:
+              type: string
+            p10_public:
+              type: string
+            p11_dd:
+              type: string
+            p12_autre:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'              
+  
+    FeatureCollectionNatureChassePeche:
+      description: Une `FeatureCollection` contenant uniquement des features de type `FeatureDivision`
+      allOf:
+        - $ref: '#/components/schemas/FeatureCollection'
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureNatureChassePeche'
+
+    FeatureRPGApartirde2015:
+      description: "Objet géographique RPG à partir de 2015" 
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Feature"
+      properties:
+        properties:
+          type: object
+          properties:
+            id_parcel:
+              type: string        
+            surf_parc:
+              type: string
+            code_cultu:
+              type: string
+            code_group:
+              type: string
+            culture_d1:
+              type: string
+            culture_d2:
+              type: string
+  
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionRPGApartirde2015:
+      description: "Liste d'objet géographique RPG"
+      type: object
+      properties:
+        type: 
+          type: string
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureRPGApartirde2015'
+  
+    FeatureRPGAvant2015:
+      description: "Objet géographique RPG avant 2015" 
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Feature"
+      properties:
+        properties:
+          type: object
+          properties:
+            num_ilot:
+              type: string        
+            commune:
+              type: string
+            forme_juri:
+              type: string
+            surf_decla:
+              type: string
+            dep_rattach:
+              type: string
+            surf_cultu:
+              type: string
+            code_cultu:
+              type: string
+            nom_cultu:
+              type: string
+  
+        geometry:
+          $ref: '#/components/schemas/MultiPolygon'
+  
+    FeatureCollectionRPGAvant2015:
+      description: "Liste d'objet géographique RPG"
+      type: object
+      properties:
+        type: 
+          type: string
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureRPGAvant2015'

--- a/doc/apicarto_chatpgt.yml
+++ b/doc/apicarto_chatpgt.yml
@@ -3,6 +3,8 @@ info:
   version: '2.7.7'
   title: API Carto multi-modules ChatGPT
   description: >
+    **Attention:** ce schema est expérimental et n'inclue pas toutes les fonctionnalités de l'apicarto. Redirigez vous aux schémas par modules pour un usage complet.
+    
     Schema OpenAPI de l'API Carto général incluant:
       - aoc: module appellations viticoles
       - cadastre: service d’interrogation du cadastre

--- a/doc/cadastre.yml
+++ b/doc/cadastre.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: Module Cadastre
@@ -67,7 +67,8 @@ info:
 
   contact:
     name: API Carto Cadastre
-
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/cadastre/commune:
     get:

--- a/doc/codes-postaux.yml
+++ b/doc/codes-postaux.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: API Carto - codes-postaux
@@ -11,6 +11,8 @@ info:
 
     Dernière mise à jour des données : 1er Mars 2023
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/codes-postaux/communes/{codePostal}:
     get:

--- a/doc/corse.yml
+++ b/doc/corse.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: Module Ressources Corse
@@ -16,6 +16,8 @@ info:
   contact:
     name: Api Carto Dreal Corse
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/corse/foretcorse:
     get:

--- a/doc/er.yml
+++ b/doc/er.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version : '2.7.7'
   title: Module Espace revendeur
@@ -16,6 +16,8 @@ info:
   contact:
     name: API Carto Espace revendeur
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/er/product:
     get:

--- a/doc/gpu.yml
+++ b/doc/gpu.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: Module urbanisme (GpU)
@@ -30,6 +30,8 @@ info:
   contact:
     name: API Carto GPU
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
 
   /api/gpu/municipality:

--- a/doc/nature.yml
+++ b/doc/nature.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 info:
   version: '2.7.7'
   title: Module Nature
@@ -47,6 +47,8 @@ info:
     name: API Carto Nature
 
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/nature/natura-habitat:
     get:

--- a/doc/rpg.yml
+++ b/doc/rpg.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 
 info:
   version: '2.7.7'
@@ -78,6 +78,8 @@ info:
        * La géométrie(champ geom) est obligatoire pour les recherches
      
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/rpg/v1:
     get:

--- a/doc/wfs-geoportail.yml
+++ b/doc/wfs-geoportail.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: '3.1.0'
 
 info:
   version: '2.7.7'
@@ -66,6 +66,8 @@ info:
       * Utilisation des flux WFS de la geoplateforme
       * Suppression du paramètre *apikey*
 
+servers:
+  - url: https://apicarto.ign.fr
 paths:
   /api/wfs-geoportail/search:
     get:


### PR DESCRIPTION
J'ai repris le travail de @MFrangi et j'ai ajouté un champ "servers" et mis a jour le numéro de version pour être conforme avec le function calling de ChatGPT.

Cependant il reste un problème lorsque l'on essaie d'importer plusieurs modules: ChatGPT n'accepte qu'un seul url et 30 routes maximales par action. Pour répondre à ce problème j'ai créé le schema combiné apicarto_chatgpt.yml qui regroupe plusieurs modules. J'ai fait le choix de laisser le module gpu de côté à cause de son grand nombre de routes pour rester sous la limite des 30.

J'ai créé un petit gpt de demonstration à cette adresse:
https://chatgpt.com/g/g-eHwp3xA7o-ign-api-carto